### PR TITLE
Adding GitHub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # SGC2019_PeaceTreesVietnam
+
+[![Actions Status](https://github.com/SeattleGiveCamp/SGC2019_PeaceTreesVietnam/workflows/Node%20CI/badge.svg)](https://github.com/SeattleGiveCamp/SGC2019_PeaceTreesVietnam/actions)


### PR DESCRIPTION
Adding GitHub badge to the README file.  This will help us check if the pipeline is passing and our commits are good.