### PR TITLE
Database

### DIFF
--- a/express.js
+++ b/express.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const mysql = require("mysql");
+const bodyParser = require("body-parser");
 require('dotenv').config();
 
 var connection = mysql.createConnection({
@@ -12,9 +13,12 @@ var connection = mysql.createConnection({
 
 const app = express();
 connection.connect();
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 app.get("/", getProject);
 app.get("/Project", getProject);
 app.get("/Ordnance", getOrdnance);
+app.post("/Project", postProject);
 
 function getProject(req, res) {
   let SQL =
@@ -36,9 +40,116 @@ function getProject(req, res) {
     "WHERE Project.location_id = Location.id;";
   connection.query(SQL, function(err, results, fields){
     if(err) console.log(err);
-    else console.log("Connected!");
+    else console.log("Sent Projects");
     console.log(results);
     res.send(results);
+  });
+}
+
+function postProject(req, res) {
+  // Sanity check the required fields. Front end will not send
+  // missing required fields, but protect against url hacking.
+  var latitude = "";
+  if (!req.body.latitude) {
+    res.status(400);
+    res.send("No latitude specified");
+    return;
+  } else {
+    latitude = req.body.latitude;
+  }
+  var longitude = "";
+  if (!req.body.longitude) {
+    res.status(400);
+    res.send("No longitude specified");
+    return;
+  } else {
+    longitude = req.body.longitude;
+  }
+  var projectName = "";
+  if (!req.body.projectName) {
+    res.status(400);
+    res.send("No projectName specified");
+    return;
+  } else {
+    projectName = req.body.projectName;
+  }
+  
+  var projectType = "";
+  if (req.body.projectType) {
+    projectType = req.body.projectType;
+  }
+  var description = "";
+  if (req.body.description) {
+    description = req.body.description;
+  }
+  var sponsors = "";
+  if (req.body.sponsors) {
+    sponsors = req.body.sponsors;
+  }
+  var dedicatedTo = "";
+  if (req.body.dedicatedTo) {
+    dedicatedTo = req.body.dedicatedTo;
+  }
+  var projectStatus = "";
+  if (req.body.projectStatus) {
+    projectStatus = req.body.projectStatus;
+  }
+  var completedYear = "";
+  if (req.body.completedYear) {
+    completedYear = req.body.completedYear;
+  }
+  var plantedYear = "";
+  if (req.body.plantedYear) {
+    plantedYear = req.body.plantedYear;
+  }
+  var imageUrl = "";
+  if (req.body.imageUrl) {
+    imageUrl = req.body.imageUrl;
+  }
+  var pageUrl = "";
+  if (req.body.pageUrl) {
+    pageUrl = req.body.pageUrl;
+  }
+
+  let locationSQL =
+    "INSERT INTO Location (latitude, longitude) VALUES (?,?);";
+  connection.query(locationSQL, [latitude, longitude], function(err, results, fields){
+    if(err) {
+      console.log(err)
+      res.status(400);
+      res.send(err);
+      return;
+    } else {
+      console.log("Inserted Location" + results.insertId);
+      locationID = results.insertId;
+        let projectSQL =
+          "INSERT INTO Project (" +
+          "projectName," +
+          "projectType," +
+          "description," +
+          "sponsors," +
+          "dedicatedTo," +
+          "projectStatus," +
+          "completedYear," +
+          "plantedYear," +
+          "imageUrl," +
+          "pageUrl," +
+          "location_id" +
+          ") VALUES (?,?,?,?,?,?,?,?,?,?,?);";
+      connection.query(
+        projectSQL,
+        [projectName, projectType, description, sponsors, dedicatedTo, projectStatus, completedYear, plantedYear, imageUrl, pageUrl, locationID],
+        function(err, results, fields){
+          if(err) {
+            console.log(err)
+            res.status(400);
+            res.send(err);
+            return;
+          } else {
+            console.log("Inserted Project" + results.insertId);
+          }
+        });
+    }
   });
 }
 
@@ -53,17 +164,6 @@ function getOrdnance(req, res) {
     if(err) console.log(err);
     else console.log("Connected!");
     console.log(results);
-    res.send(results);
-  });
-}
-
-function getData(req, res) {
-  let SQL="SELECT * FROM Location";
-  connection.query(SQL, function(err, results, fields){
-    if(err) console.log(err);
-    else console.log("Connected!");
-    console.log(results);
-
     res.send(results);
   });
 }

--- a/scripts/create_database.sql
+++ b/scripts/create_database.sql
@@ -63,10 +63,10 @@ CREATE TABLE Project (
     pageUrl VARCHAR(200),
     notes TEXT,
     location_id INT NOT NULL,
-    FOREIGN KEY (location_id) REFERENCES Location(id)
-    FOREIGN KEY (projectType) REFERENCES ProjectCategory(id)
+    FOREIGN KEY (location_id) REFERENCES Location(id),
+    FOREIGN KEY (projectType) REFERENCES ProjectCategory(id),
     FOREIGN KEY (projectStatus) REFERENCES ProjectStatus(id)
-);
+) CHARACTER SET utf8mb4;
 COMMIT;
 CREATE TABLE Ordnance (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
This supports POST to /Project, for inserts.  The fields are required to include only projectName, latitude, longitude.  The latter two go into a Location record, to which the Project record has a foreign key reference.

There's one more possible change needed to this, which is to consider whether we want to share location records between project entries or ordnance entries, to avoid duplication.  The only complication is that if the location of some entity is changes, and the location is shared, a new location must be created.  That's not much overhead, but if duplicates are rare, this is moot, and we should just have a separate location per entity.